### PR TITLE
Allow offline mode for inference

### DIFF
--- a/src/boltzgen/cli/boltzgen.py
+++ b/src/boltzgen/cli/boltzgen.py
@@ -322,6 +322,12 @@ def add_configure_arguments(
         help="Threshold used for RMSD-based filters (lower is better).",
         default=None,
     )
+    p.add_argument(
+        "--local_files_only",
+        action="store_true",
+        help="Run in offline mode, use model weights and data from the local cache.",
+        default=False,
+    )
 
 
 def add_models_download_options(p: argparse.ArgumentParser) -> None:
@@ -1291,6 +1297,7 @@ def get_artifact_path(
             library_name="boltzgen",
             force_download=args.force_download,
             token=args.models_token,
+            local_files_only=args.local_files_only,
             cache_dir=args.cache,
         )
         result = Path(result)


### PR DESCRIPTION
# Background

Huge fan of the repo and paper, great job @HannesStark and team!

This PR adds a new argument to the inference pipeline to allow us to run it in "offline mode", mostly by telling the huggingface client not to send any outbound requests. 

This parameter exactly mirrors the huggingface hub argument of the same name documented here:  https://huggingface.co/docs/huggingface_hub/en/package_reference/file_download

Let me know if you need any more information about this change or if there are any other suggestions you have here, happy to help get this change integrated. Congrats on the launch!