### PR TITLE
fix: download command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG DOWNLOAD_WEIGHTS=false
 ARG HF_TOKEN=""
 RUN mkdir -p "${HF_HOME}" && \
     if [ "${DOWNLOAD_WEIGHTS}" = "true" ]; then \
-        HF_TOKEN="${HF_TOKEN}" boltzgen download --models-cache-dir "${HF_HOME}" --force-download --show-paths; \
+        HF_TOKEN="${HF_TOKEN}" boltzgen download --cache "${HF_HOME}" --force_download; \
     fi
 
 ARG USERNAME=boltzgen


### PR DESCRIPTION
Hi, Thanks for the great work!

I found a small inconsistency in the `Dockerfile`:
https://github.com/HannesStark/boltzgen/blob/d4b8206974262ff6c72c7a7874283b3441f0aacd/Dockerfile#L46-L48

But in `src/boltzgen/cli/boltzgen.py`:
https://github.com/HannesStark/boltzgen/blob/d4b8206974262ff6c72c7a7874283b3441f0aacd/src/boltzgen/cli/boltzgen.py#L327-L346

And in `README.md`:
https://github.com/HannesStark/boltzgen/blob/d4b8206974262ff6c72c7a7874283b3441f0aacd/README.md?plain=1#L409-L412
