### PR TITLE
Save diffusion trajectory in mmCIF format instead of PDB

### DIFF
--- a/src/boltzgen/task/predict/writer.py
+++ b/src/boltzgen/task/predict/writer.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 import numpy as np
 import torch
+import gemmi
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import BasePredictionWriter
 from torch import Tensor
@@ -517,8 +518,6 @@ class DesignWriter(BasePredictionWriter):
                 print(msg)
 
     def combine_mmcif_models(self, mmcif_strings):
-        import gemmi
-
         gemmi_structure = gemmi.Structure()
         for model_number, mmcif_string in enumerate(mmcif_strings, start=1):
             block = gemmi.cif.read_string(mmcif_string).sole_block()


### PR DESCRIPTION
This PR writes the xt/x0 trajectory from the denoising process to mmCIF rather than PDB. Early timesteps can produce very large coordinates that exceed the fixed-width XYZ fields in PDB. mmCIF does not have these field-width constraints, ensuring the trajectory is stored faithfully.