### PR TITLE
fix: correct filter conditions to use strict inequalities

### DIFF
--- a/src/boltzgen/task/filter/filter.py
+++ b/src/boltzgen/task/filter/filter.py
@@ -399,9 +399,9 @@ class Filter(Task):
             filter_col = f"pass_{feat}_filter"
             filter_cols.append(filter_col)
             if low:
-                self.df[filter_col] = self.df[feat] <= threshold
+                self.df[filter_col] = self.df[feat] < threshold
             else:
-                self.df[filter_col] = self.df[feat] >= threshold
+                self.df[filter_col] = self.df[feat] > threshold
 
             self.df["num_filters_passed"] += self.df[filter_cols].all(axis=1)
             self.df["pass_filters"] = self.df[filter_cols].all(axis=1)


### PR DESCRIPTION
Such that the actual filtering aligns with filter definitions, e.g.

`--additional_filters 'ALA_fraction<0.3' 'filter_rmsd_design<2.5'`