### PR TITLE
Clamp analyze worker thread pools to prevent oversubscribing

### DIFF
--- a/src/boltzgen/task/analyze/analyze.py
+++ b/src/boltzgen/task/analyze/analyze.py
@@ -153,6 +153,10 @@ class Analyze(Task):
         self.slurm = slurm
         self.diversity_subset = diversity_subset
 
+        # Prevent each worker process from spawning its own multithreaded pools
+        torch.set_num_threads(1)
+        torch.set_num_interop_threads(1)
+
         if design_dir is not None:
             self.init_datasets(design_dir, load_dataset=False)
 


### PR DESCRIPTION
Increasing `--config analysis num_processes` does not always result in speedup for the analysis step and sometimes results in a slowdown, even when well below the number of CPUs. On a machine with 256 CPUs, going from `num_processes=32` to `num_processes=128` resulted in a ~2x slowdown in analysis time.

I think this is caused by MKL defaulting to 8 threads within each process, oversubscribing the host. This PR sets the number of threads within each process to 1 to prevent oversubscription.

In my test, this took the time to analyze 60k designs from ~24h to ~2h.