### PR TITLE
Fix residue range checks to run on every `spec` in `spec_list`

### DIFF
--- a/src/boltzgen/data/parse/schema.py
+++ b/src/boltzgen/data/parse/schema.py
@@ -648,7 +648,7 @@ def parse_range(ranges, c_start=0, c_end=None):
         if re.fullmatch(r"\d+", spec):
             # Single number. Convert it from 1 indexed to 0 indexed.
             start = int(spec) - 1
-            end = start
+            end = int(spec) - 1
             indices.append(c_start + start)
         elif re.fullmatch(r"\d+..\d+", spec):
             # Range with start and end. Convert the start from 1 indexed to 0 indexed. Leave the end untouched because the specification is inclusive (+1) but 1 indexed (-1).


### PR DESCRIPTION
`parse_range` currently checks the start and end residues after looping over all specs, leading to missed checks.

E.g. setting binding residues to `0,5..10` does not trigger a `ValueError`, even though residue 0 is out of range for 1-indexed residues, resulting in residue -1 being silently set as binding. 

This PR ensures the check catches these cases.