### PR TITLE
Fix delta SASA to use design chain mask

### DIFF
--- a/src/boltzgen/task/analyze/analyze.py
+++ b/src/boltzgen/task/analyze/analyze.py
@@ -584,15 +584,26 @@ class Analyze(Task):
         atom_resolved_mask = feat["atom_resolved_mask"]
         resolved_atoms_design_mask = atom_design_resolved_mask[atom_resolved_mask]
         resolved_atoms_target_mask = atom_target_resolved_mask[atom_resolved_mask]
-        design_mask_for_chain = feat["asym_id"] == design_chain_id
+        chain_design_mask = feat["chain_design_mask"].bool()
         atom_chain_mask = (
+            (feat["atom_to_token"].float() @ chain_design_mask.unsqueeze(-1).float())
+            .bool()
+            .squeeze()
+        )
+        chain_design_resolved_mask = (
+            chain_design_mask & feat["token_resolved_mask"].bool()
+        )
+        atom_chain_design_resolved_mask = (
             (
                 feat["atom_to_token"].float()
-                @ design_mask_for_chain.unsqueeze(-1).float()
+                @ chain_design_resolved_mask.unsqueeze(-1).float()
             )
             .bool()
             .squeeze()
         )
+        resolved_atoms_chain_design_mask = atom_chain_design_resolved_mask[
+            atom_resolved_mask
+        ]
 
         # Get masks for native structure
         if self.native:
@@ -669,7 +680,7 @@ class Analyze(Task):
                 delta_sasa_orig,
                 design_sasa_unbound,
                 design_sasa_bound,
-            ) = get_delta_sasa(path, resolved_atoms_target_mask)
+            ) = get_delta_sasa(path, resolved_atoms_chain_design_mask)
             metrics["delta_sasa_original"] = delta_sasa_orig
             metrics["design_sasa_unbound_original"] = design_sasa_unbound
             metrics["design_sasa_bound_original"] = design_sasa_bound
@@ -1044,7 +1055,9 @@ class Analyze(Task):
                     delta_sasa_refolded,
                     design_sasa_unbound,
                     design_sasa_bound,
-                ) = get_delta_sasa(cif_path_refolded, resolved_atoms_target_mask)
+                ) = get_delta_sasa(
+                    cif_path_refolded, resolved_atoms_chain_design_mask
+                )
 
                 metrics["delta_sasa_refolded"] = delta_sasa_refolded
                 metrics["design_sasa_unbound_refolded"] = design_sasa_unbound


### PR DESCRIPTION
This PR applies the fix from [4f331de](https://github.com/HannesStark/boltzgen/commit/4f331de0ade08f74318fd65676a525d6681eebea) to the delta SASA calculations, which currently calculate delta SASA between designed/not-designed residues instead of designed/not-designed chains. 

Addresses #109. 