### PR TITLE
Use consistent confidence metrics to select best design in writer vs analyze

### DIFF
--- a/src/boltzgen/task/predict/writer.py
+++ b/src/boltzgen/task/predict/writer.py
@@ -69,7 +69,7 @@ class FoldingWriter(BasePredictionWriter):
         np.savez_compressed(self.outdir / f"{batch['id'][0]}.npz", **pred_dict)
 
         # Get best sample
-        confidence = 0.8 * pred_dict["iptm"] + 0.2 * pred_dict["ptm"]
+        confidence = 0.8 * pred_dict["design_to_target_iptm"] + 0.2 * pred_dict["design_ptm"]
         best_idx = np.argmax(confidence)
         best_sample_coords = pred_dict["coords"][best_idx]
 


### PR DESCRIPTION
A simple proposed fix for #127 

Ideally one may want to make this criteria configurable, this PR is just a minimal change to avoid the inconsistency. Note that this may change the pipeline results a bit.