### PR TITLE
Bug fix: resolved the issue where some identical chains in a homo-oli…

### DIFF
--- a/src/boltzgen/data/parse/pdb_parser.py
+++ b/src/boltzgen/data/parse/pdb_parser.py
@@ -59,6 +59,18 @@ def parse_pdb(  # noqa: C901, PLR0915, PLR0912
                 sc[i].label_seq = j + 1
                 i += 1
 
+        # Fix: Set label_seq for all subchains in the same entity, not just the first one
+        # This is important when multiple chains (e.g., A, B, C) belong to the same entity
+        for subchain_id in entity.subchains[1:]:  # Skip the first one, already processed
+            subchain = st[0].get_subchain(subchain_id)
+            if subchain is not None:
+                # Use the same alignment result for all subchains in the same entity
+                i = 0
+                for j, align in enumerate(align_result):
+                    if align == "|" and i < len(subchain):
+                        subchain[i].label_seq = j + 1
+                        i += 1
+
     block = st.make_mmcif_block()
 
     structure = mmcif_from_block(


### PR DESCRIPTION
When designing specific residues in a known homooligomer, the pipeline occasionally outputs a structure that contains only one copy of the identical chains, triggering an error.  
For example, the below structure has five chains: A, B, C, D, E, where A, B and C form a homooligomer. After the first design step, the returned model keeps only chains A, D and E, while chains B and C are silently dropped. The resulting error message is as follows:
  File "/data/PRG/tools/boltz/apps/boltzgen/src/boltzgen/task/predict/data_from_generated.py", line 321, in getitem_from_paths
    feat = self.get_feat(generated_path, design_mask, ss_type, binding_type)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/PRG/tools/boltz/apps/boltzgen/src/boltzgen/task/predict/data_from_generated.py", line 379, in get_feat
    design_chains = np.unique(asym_id[chain_design_mask])
                              ~~~~~~~^^^^^^^^^^^^^^^^^^^
IndexError: boolean index did not match indexed array along axis 0; size of axis is 391 but size of corresponding boolean axis is 715

The yaml file are as following:

[design_spec.yaml](https://github.com/user-attachments/files/24360238/design_spec.yaml)

The reason is that: in the parse_pdb function (src/boltzgen/data/parse/pdb_parser.py), label_seq was assigned only to the first sub-chain (chain A) of an entity, while the remaining identical sub-chains (B and C) were left without label_seq.
After adding the corresponding fix, the issue was resolved.
