### PR TITLE
Bug fix: compute delta SASA between designed and non-designed chain(s)

### DIFF
--- a/src/boltzgen/task/analyze/analyze.py
+++ b/src/boltzgen/task/analyze/analyze.py
@@ -604,6 +604,7 @@ class Analyze(Task):
         design_resolved_mask = design_mask & feat["token_resolved_mask"].bool()
 
         target_resolved_mask = (~chain_design_mask) & feat["token_resolved_mask"].bool()
+        chain_design_resolved_mask = chain_design_mask & feat["token_resolved_mask"].bool()
         atom_design_resolved_mask = (
             (feat["atom_to_token"].float() @ design_resolved_mask.unsqueeze(-1).float())
             .bool()
@@ -614,9 +615,15 @@ class Analyze(Task):
             .bool()
             .squeeze()
         )
+        atom_chain_design_resolved_mask = (
+            (feat["atom_to_token"].float() @ chain_design_resolved_mask.unsqueeze(-1).float())
+            .bool()
+            .squeeze()
+        )
         atom_resolved_mask = feat["atom_resolved_mask"]
         resolved_atoms_design_mask = atom_design_resolved_mask[atom_resolved_mask]
         resolved_atoms_target_mask = atom_target_resolved_mask[atom_resolved_mask]
+        resolved_atoms_chain_design_mask = atom_chain_design_resolved_mask[atom_resolved_mask]
         atom_chain_mask = (
             (
                 feat["atom_to_token"].float()
@@ -704,7 +711,7 @@ class Analyze(Task):
             ) = get_delta_sasa(
                 path,
                 atom_target_mask=resolved_atoms_target_mask,
-                atom_design_mask=resolved_atoms_design_mask,
+                atom_design_mask=resolved_atoms_chain_design_mask,
             )
             metrics["delta_sasa_original"] = delta_sasa_orig
             metrics["design_sasa_unbound_original"] = design_sasa_unbound
@@ -1088,7 +1095,7 @@ class Analyze(Task):
                 ) = get_delta_sasa(
                     cif_path_refolded,
                     atom_target_mask=resolved_atoms_target_mask,
-                    atom_design_mask=resolved_atoms_design_mask,
+                    atom_design_mask=resolved_atoms_chain_design_mask,
                 )
 
                 metrics["delta_sasa_refolded"] = delta_sasa_refolded


### PR DESCRIPTION
It looks like there's a bug in the current delta SASA computations that results in significant delta SASA discrepancies. Delta SASA is computed using the mask built from the designed residues instead of the designed chain(s).

I've tested the change in this PR on an antibody where I re-design a single residue in CDRH3. With the bug, the delta SASAs are ~8A^2, reflecting that it's being computed only for that residue, not for the entire chain. With the fix in this PR, I see values ~1300A^2, which matches the true interface size.

The hydrogen bond and salt bridge masking is correct in the version currently in main - these compare the entire designed chain(s) and the target chain(s).