### PR TITLE
Bug fix: check residue specs for 0-indexing

### DIFF
--- a/src/boltzgen/data/parse/schema.py
+++ b/src/boltzgen/data/parse/schema.py
@@ -665,13 +665,16 @@ def parse_range(ranges, c_start=0, c_end=None):
             start -= 1
             end = c_end - c_start
             indices += list(range(c_start + start, c_end))
-    if start < 0:
-        msg = f"There is a 0 in the specified range(s) {ranges}. Residue indices are 1 indexed."
-        raise ValueError(msg)
+        else:
+            continue
 
-    if c_end is not None and end > c_end - c_start:
-        msg = f"Specified end {ranges} is higher than the length of the chain."
-        raise ValueError(msg)
+        if start < 0:
+            msg = f"There is a 0 in the specified range(s) {ranges}. Residue indices are 1 indexed."
+            raise ValueError(msg)
+
+        if c_end is not None and end > c_end - c_start:
+            msg = f"Specified end {ranges} is higher than the length of the chain."
+            raise ValueError(msg)
     return indices
 
 


### PR DESCRIPTION
Just a small fix on residue spec validation. Residues in the config are checked for 0-indexing and out of range, but it looks like these checks were accidentally written outside the `spec_list` loop, resulting in everything except the final spec not being checked (e.g. `0..10,15..20` will not fail the check, because only the final spec, `15..20` is actually checked).

This has bitten me a few times when automatically extracting contacts and forgetting to 1-index them - the check will pass and it will silently apply the spec for residue 0 to residue -1.

(Sorry for the duplicate PR, I opened this in #98 but accidentally deleted my branch, so re-opening here.) 