### PR TITLE
Fix atom_to_token remapping for variable insertions in visibility=1 scaffolds, respect defined structure_groups visibility and constraint validation for file entities, and CIF writer

### DIFF
--- a/src/boltzgen/data/parse/schema.py
+++ b/src/boltzgen/data/parse/schema.py
@@ -1476,12 +1476,14 @@ class YamlDesignParser:
                 if c2 in total_renaming.keys():
                     c2 = total_renaming[c2]
 
-                if c1 not in all_parsed_chains.keys():
+                # Check if chain exists in either parsed_chains (protein/ligand) or data.chains (file entities)
+                chain_names_in_data = {chain["name"].item() for chain in data.chains}
+                if c1 not in all_parsed_chains.keys() and c1 not in chain_names_in_data:
                     msg = f"Chain {c1} in the specified connection does not exist: {constraint}"
-                    ValueError(msg)
-                if c2 not in all_parsed_chains.keys():
+                    raise ValueError(msg)
+                if c2 not in all_parsed_chains.keys() and c2 not in chain_names_in_data:
                     msg = f"Chain {c2} in the specified connection does not exist: {constraint}"
-                    ValueError(msg)
+                    raise ValueError(msg)
 
                 # Map index
                 if (
@@ -1861,7 +1863,8 @@ class YamlDesignParser:
 
                 # Handle the "all" case where all chains are set to be specified
                 if chain_id == "all":
-                    new_groups = np.ones(num_res)
+                    visibility = group["visibility"]
+                    new_groups = np.full(num_res, visibility, dtype=np.int32)
                     continue
 
                 if chain_id not in structure.chains["name"]:

--- a/src/boltzgen/data/write/mmcif.py
+++ b/src/boltzgen/data/write/mmcif.py
@@ -309,6 +309,7 @@ def add_design_cols(structure, block, colors):
         "metric_value",
     ]
     plddt_loop = block.init_loop("_ma_qa_metric_local.", plddt_cols)
+    ordinal_id = 0
     global_res_idx = -1
     for chain in structure.chains:
         chain_name_str = re.sub(r"\d+", "", chain["name"].item())
@@ -322,11 +323,12 @@ def add_design_cols(structure, block, colors):
             global_res_idx += 1
             if not res["is_present"]:
                 continue
+            ordinal_id += 1
             mon_id = res["name"].item()
             design_label = colors[global_res_idx]  # [plddt_loop.length()]
             plddt_loop.add_row(
                 [
-                    str(plddt_loop.length() + 1),  # ordinal_id
+                    str(ordinal_id),  # ordinal_id
                     "1",  # model_id
                     chain_id,  # label_asym_id
                     str(res["res_idx"].item() + 1),
@@ -362,6 +364,7 @@ def add_plddt_cols(structure, block):
         "metric_value",
     ]
     plddt_loop = block.init_loop("_ma_qa_metric_local.", plddt_cols)
+    ordinal_id = 0
     for chain in structure.chains:
         if chain["mol_type"].item() == const.chain_type_ids["NONPOLYMER"]:
             continue
@@ -376,12 +379,13 @@ def add_plddt_cols(structure, block):
         for _, res in enumerate(residues, 1):
             if not res["is_present"]:
                 continue
+            ordinal_id += 1
             mon_id = res["name"].item()
             ref_atom_idx = res["atom_idx"]
             plddt_score = structure.atoms[ref_atom_idx]["bfactor"].item()
             plddt_loop.add_row(
                 [
-                    str(plddt_loop.length() + 1),  # ordinal_id
+                    str(ordinal_id),  # ordinal_id
                     "1",  # model_id
                     chain_id,  # label_asym_id
                     str(res["res_idx"].item() + 1),


### PR DESCRIPTION
Hey! Couple things that come up when working with file-based templates, constraints, etc.


File | Issue | Fix
-- | -- | --
data.py | Mid-sequence padding causes atom_to_token misalignment | Remap indices after filtering
mmcif.py | loop.length() unreliable with missing residues | Manual counter for sequential IDs
schema.py | id: "all" ignores visibility value | Respect user-specified visibility
schema.py | Missing constraint validation for file chains | Check both parsed and file chains


[pr155-changes.md](https://github.com/user-attachments/files/24699862/pr155-changes.md)
