### PR TITLE
Fix analysis crash when SASA atom selection is empty - Small molecule example

### DIFF
--- a/src/boltzgen/task/analyze/analyze_utils.py
+++ b/src/boltzgen/task/analyze/analyze_utils.py
@@ -689,13 +689,17 @@ def get_delta_sasa(
         [_radius(rn, an, el) for rn, an, el in zip(target_res, target_atm, target_elem)],
         dtype=float,
     )
-    target_area = sasa(
-        target_atoms,
-        probe_radius=1.4,
-        point_number=960,
-        vdw_radii=radii_lig,
-    )
-    delta = target_area.sum() - target_bound
+    try:
+        target_area = sasa(
+            target_atoms,
+            probe_radius=1.4,
+            point_number=960,
+            vdw_radii=radii_lig,
+        )
+        delta = target_area.sum() - target_bound
+    except ValueError:
+        return float("nan"), float("nan"), float("nan")
+    
     return delta, target_area.sum(), target_bound
 
 


### PR DESCRIPTION
Fix analysis crash: `ValueError: Coordinates are empty` in `get_delta_sasa()`

- **Fixes**: #166 

### Problem
Running `boltzgen run example/small_molecule_from_file_and_smiles/4g37.yaml --protocol protein-anything` on `v0.2.0` can fail in **step 5/6: analysis**:

- `ValueError: Coordinates are empty` (Biotite `sasa()`)

### Root cause
`boltzgen/task/analyze/analyze_utils.py:get_delta_sasa()` calls Biotite `sasa()` on an atom selection that can be empty for some inputs, which Biotite rejects.

### Fix
File: `boltzgen/task/analyze/analyze_utils.py`

- Catch `ValueError` from the `sasa(target_atoms, ...)` call and return `(nan, nan, nan)` for the SASA metrics instead of aborting the pipeline.

### Behavior change
- Pipeline no longer crashes in analysis.
- SASA-related metrics become `NaN` when the SASA selection is empty.

### Test
```bash
boltzgen run example/small_molecule_from_file_and_smiles/4g37.yaml \
  --output workbench \
  --protocol protein-anything \
  --num_designs 2
```