### PR TITLE
Fix gontivimab scaffold path reference

### DIFF
--- a/example/nanobody_scaffolds/gontivimab.yaml
+++ b/example/nanobody_scaffolds/gontivimab.yaml
@@ -1,4 +1,4 @@
-path: sonelokimab.cif
+path: gontivimab.cif
 include: 
   - chain: 
       id: A


### PR DESCRIPTION
Recently uploaded nanobody scaffold *gontivimab* erroneously references *sonelokimab*. This fixes that.