### PR TITLE
Fix gontivimab.yaml nanobody example to use gontivimab.cif scaffold

### DIFF
--- a/example/nanobody_scaffolds/gontivimab.yaml
+++ b/example/nanobody_scaffolds/gontivimab.yaml
@@ -1,4 +1,4 @@
-path: sonelokimab.cif
+path: gontivimab.cif
 include: 
   - chain: 
       id: A


### PR DESCRIPTION
The `gontivimab.yaml` nanobody example config was using the `sonelokimab.cif` scaffold - I presume this is in error and it should be using `gontivimab.cif`. This PR fixes that.