### PR TITLE
fix: bug in num_filters_passed counting

### DIFF
--- a/src/boltzgen/data/const.py
+++ b/src/boltzgen/data/const.py
@@ -3475,7 +3475,6 @@ eval_keys_confidence = [
     "design_ipsae_min",
     "design_to_target_ipsae",
     "target_to_design_ipsae",
-    "ligand_iptm",
     "complex_plddt",
     "complex_iplddt",
     "complex_pde",

--- a/src/boltzgen/task/filter/filter.py
+++ b/src/boltzgen/task/filter/filter.py
@@ -408,7 +408,7 @@ class Filter(Task):
             else:
                 self.df[filter_col] = self.df[feat] >= threshold
 
-            self.df["num_filters_passed"] += self.df[filter_cols].all(axis=1)
+            self.df["num_filters_passed"] += self.df[filter_col].astype(int)
             self.df["pass_filters"] = self.df[filter_cols].all(axis=1)
 
             msg = f"Num designs that pass the {feat} filter with threshold {threshold} where {'lower' if low else 'higher'} is better: {self.df[filter_col].sum()}"


### PR DESCRIPTION
## fix bug in `num_filters_passed`
- fix #126 https://github.com/HannesStark/boltzgen/blob/f3392feefd0ca0f8bc9f39004d20932c1388fda6/src/boltzgen/task/filter/filter.py#L408-L409
- should be
```diff
-            self.df["num_filters_passed"] += self.df[filter_cols].all(axis=1) # cumulative all-pass check
+            self.df["num_filters_passed"] += self.df[filter_col].astype(int)  # only cumulative this filter
             self.df["pass_filters"] = self.df[filter_cols].all(axis=1) 
```
- verify the bug from data (in the `final_ranked_designs` dir)
```python
import pandas as pd
df = pd.read_csv("./all_designs_metrics.csv")
filter_cols = [c for c in df.columns if c.startswith("pass_") and c.endswith("_filter")]
expected = df[filter_cols].sum(axis=1).astype(int)

# buggy data
print(df["num_filters_passed"].astype(int).value_counts().sort_index())
# expected data
print(expected.value_counts().sort_index())

mismatch = (df["num_filters_passed"].astype(int) != expected).sum()
print(f"Mismatched rows: {mismatch} / {len(df)}")
```
- Luckily, the budget is typically small so that `final_designs_metrics_{n}.csv` only contains designs passing all filters. The final selection is usually unaffected (in my experience)

---

## remove duplicate `ligand_iptm` 
- fix #135  https://github.com/HannesStark/boltzgen/blob/81b5e1da0c5a773a39a36fa79b6f7d7c82c0ebf9/src/boltzgen/data/const.py#L3461-L3463 and https://github.com/HannesStark/boltzgen/blob/81b5e1da0c5a773a39a36fa79b6f7d7c82c0ebf9/src/boltzgen/data/const.py#L3477-L3483
- just remove the duplicate one