### PR TITLE
Add docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,64 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'Dockerfile'
+      - '.github/workflows/docker-publish.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Repository name lowercase
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,enable=${{github.event_name == 'workflow_dispatch'}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DOWNLOAD_WEIGHTS=false
+          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_LC }}-cache:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_LC }}-cache:buildcache,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,3 +62,18 @@ jobs:
             DOWNLOAD_WEIGHTS=false
           cache-from: type=registry,ref=ghcr.io/${{ env.REPO_LC }}-cache:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ env.REPO_LC }}-cache:buildcache,mode=max
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old container images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: ^v\d+\.\d+\.\d+$

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     CUDA_HOME=/usr/local/cuda \
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu121 \
-    HF_HOME=/cache
+    HF_HOME=/cache \
+    NUMBA_CACHE_DIR=/tmp/numba_cache \
+    TRITON_CACHE_DIR=/tmp/triton_cache \
+    XDG_CACHE_HOME=/tmp/xdg_cache
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu121 \
     HF_HOME=/cache
-    
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     software-properties-common \
@@ -40,9 +40,14 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 &
 
 WORKDIR /app
 
-COPY . /app
+# Install dependencies (cached unless pyproject.toml changes)
+COPY pyproject.toml PYPI_DESCRIPTION.md /app/
+COPY src/boltzgen/__init__.py /app/src/boltzgen/__init__.py
+RUN pip install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cu121 \
+    -e /app "torch>=2.4.1,<2.10"
 
-RUN pip install --no-cache-dir -e /app
+COPY . /app
 
 ARG DOWNLOAD_WEIGHTS=false
 RUN mkdir -p "${HF_HOME}" && \


### PR DESCRIPTION
Hi, thanks for this repo! it's been really useful for my work!

---

I'd love to have an official docker image so I can just pull on our server instead of manually check for update and rebuilding. 
So I put together everything and make this PR.

1. Add `docker-publish.yml`
	- 	Using github actions to build and push the docker image to github `ghcr.io`
2. Reroder the `Dockerfile` for better caching
3. Fix cache path for non-root user
	- `PermissionError: [Errno 13] Permission denied: '/.cache'`
	- `RuntimeError: cannot cache function '_prepare_msa_arrays_inner': no locator available for file '/app/src/boltzgen/data/feature/featurizer.py'`
- Fix #101 

I have been using this setup in my own workflow (github actions to build the image + a self-hosted runner to test).
I thought this setup is quite useful, so I wanted to share the config and hope it may be helpful for others as well.

---

My github actions logs:
- This workflow: https://github.com/chAwater/boltzgen/actions/runs/24318322994
- With testing on self-hosted runner: https://github.com/chAwater/boltzgen/actions/runs/24365191605
- Cache path error when using non-root user
	- https://github.com/chAwater/boltzgen/actions/runs/24270500287/job/70875243752
	- https://github.com/chAwater/boltzgen/actions/runs/24278305500/job/70896935265