### PR TITLE
Fix binding_types dropping 'binding' when combined with 'not_binding'

### DIFF
--- a/src/boltzgen/data/parse/schema.py
+++ b/src/boltzgen/data/parse/schema.py
@@ -2201,6 +2201,13 @@ class YamlDesignParser:
                 c_end = c_start + data_chain["res_num"].item()
 
                 # Set values
+                if "binding" in chain:
+                    binding = chain["binding"]
+                    if binding == "all":
+                        fbind_types[c_start:c_end] = const.binding_type_ids["BINDING"]
+                    else:
+                        indices = parse_range(binding, c_start, c_end)
+                        fbind_types[indices] = const.binding_type_ids["BINDING"]
                 if "not_binding" in chain:
                     not_binding = chain["not_binding"]
                     if not_binding == "all":
@@ -2210,13 +2217,6 @@ class YamlDesignParser:
                     else:
                         indices = parse_range(not_binding, c_start, c_end)
                         fbind_types[indices] = const.binding_type_ids["NOT_BINDING"]
-                elif "binding" in chain:
-                    binding = chain["binding"]
-                    if binding == "all":
-                        fbind_types[c_start:c_end] = const.binding_type_ids["BINDING"]
-                    else:
-                        indices = parse_range(binding, c_start, c_end)
-                        fbind_types[indices] = const.binding_type_ids["BINDING"]
 
         # Get file's secondary structure types called fss_types
         fss_type = np.ones(num_res) * const.ss_type_ids["UNSPECIFIED"]


### PR DESCRIPTION
The binding_types parser of `file:` used if/elif, so when a chain block contained both 'binding' and 'not_binding' keys, only 'not_binding' was applied and 'binding' was ignored. I just switched to two if-blocks.

The example in example/binding_disordered_regions_of_proteins/npm1.yaml uses the combined kind and its comment states that both should apply, so this follows intended behavior.