### PR TITLE
Use antibody liability modality for nanobody/antibody protocols instead of peptide default

### DIFF
--- a/src/boltzgen/cli/boltzgen.py
+++ b/src/boltzgen/cli/boltzgen.py
@@ -93,11 +93,19 @@ protocol_configs = {
         "filtering": ["use_affinity=true"],
     },
     "nanobody-anything": {
-        "analysis": ["largest_hydrophobic=false", "largest_hydrophobic_refolded=false"],
+        "analysis": [
+            "largest_hydrophobic=false",
+            "largest_hydrophobic_refolded=false",
+            "liability_modality=antibody",
+        ],
         "filtering": ["filter_cysteine=true"],
     },
     "antibody-anything": {
-        "analysis": ["largest_hydrophobic=false", "largest_hydrophobic_refolded=false"],
+        "analysis": [
+            "largest_hydrophobic=false",
+            "largest_hydrophobic_refolded=false",
+            "liability_modality=antibody",
+        ],
         "filtering": ["filter_cysteine=true"],
     },
     "protein-redesign": {


### PR DESCRIPTION
Raised in issue #228

The `nanobody-anything` and `antibody-anything` protocols inherited default `liability_modality: peptide` (from analysis.yaml), so liability analysis scored designed CDRs against peptide rules instead of antibody ones. I just added `liability_modality=antibody` to both protocols' analysis overrides in `protocol_configs` so the correct panel is produced by default. There isn't an explicit statement that this is intended, but it makes the most sense to use antibody rules for antibody runs. Users can still override with `--config analysis liability_modality=...`.