### PR TITLE
Fix O(N^2) serialization in analysis step

### DIFF
--- a/src/boltzgen/task/analyze/analyze.py
+++ b/src/boltzgen/task/analyze/analyze.py
@@ -53,6 +53,23 @@ from boltzgen.data.data import Structure
 from boltzgen.data.write.mmcif import to_mmcif
 
 
+_WORKER_ANALYZE = None
+
+
+def _init_worker(analyze):
+    """Worker process with single pickled copy of the Analyze task"""
+    global _WORKER_ANALYZE
+    _WORKER_ANALYZE = analyze
+    torch.set_num_threads(1)
+    torch.set_num_interop_threads(1)
+    rdkit.Chem.SetDefaultPickleProperties(rdkit.Chem.PropertyPickleOptions.AllProps)
+
+
+def _worker_compute_metrics(idx):
+    """Module-level. Only the index is pickled per submission"""
+    return _WORKER_ANALYZE.compute_metrics(idx)
+
+
 class Analyze(Task):
     """
     The Analyze step of the BoltzGen pipeline.
@@ -205,9 +222,15 @@ class Analyze(Task):
 
             try:
                 with ProcessPoolExecutor(
-                    max_workers=num_processes, mp_context=ctx
+                    max_workers=num_processes,
+                    mp_context=ctx,
+                    initializer=_init_worker,
+                    initargs=(self,),
                 ) as ex:
-                    fut2idx = {ex.submit(self.compute_metrics, i): i for i in remaining}
+                    # Submit only index
+                    fut2idx = {
+                        ex.submit(_worker_compute_metrics, i): i for i in remaining
+                    }
 
                     # Iterate over futures that actually *completed* (finished or raised)
                     for f in as_completed(fut2idx):


### PR DESCRIPTION
In `Analyze.run_parallel`, tasks are submitted as `ex.submit(self.compute_metrics, i)`. Submitting a bound method pickles `self`. That is, the entire `Analyze` object, including `self.data.predict_set`, which holds one path per design, gets pickled for each task. This means O(n_designs^2) serialization time, which is expensive in the low 10s of thousands of designs range, and blows up in the high 10s of thousands/low 100s of thousands range. 

This PR pickles `self` once per worker instead of once per task. 

I tested this change on a 50k design run and see a per-task pickle size drop from ~9MB to 16 bytes. On a 100k design run this takes the estimated analysis time from ~18hrs to ~1.5hrs. 