### PR TITLE
Relax numpy and numba hard pins to lower bounds (#220)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ readme = { file = "PYPI_DESCRIPTION.md", content-type = "text/markdown" }
 description = "Protein design"
 dependencies = [
     # Add runtime dependencies here
-    "numpy==2.0.2",
-    "numba==0.61.0",
+    "numpy>=2.0.2",
+    "numba>=0.61.0",
     "matplotlib",
     "hydride",
     "biotite",


### PR DESCRIPTION
Relax numpy and numba hard pins to lower bounds (#220)Relaxes the hard pins on numpy and numba to lower bounds, as requested in #220.

- numpy==2.0.2 -> numpy>=2.0.2
- numba==0.61.0 -> numba>=0.61.0

numpy 2.0.2 only supports Python <=3.12, which blocks use on 3.13.
Relaxing to >= allows numpy 2.1+ (which supports 3.13) to be selected.

This is safe because numba pins numpy on both bounds in its own
metadata, so the resolver will always co-select a compatible
numpy/numba pair rather than an incompatible one.

Closes #220